### PR TITLE
Replace n*2 queries with a single one and fix tasks migration

### DIFF
--- a/app/Http/Livewire/TasksTable.php
+++ b/app/Http/Livewire/TasksTable.php
@@ -18,8 +18,13 @@ class TasksTable extends Component
 
     public function updateTaskOrder($tasks)
     {
-        foreach ($tasks as $task) {
-            Task::find($task['value'])->update(['position' => $task['order']]);
-        }
+        $tasks = array_map(function ($task) {
+            return [
+                'position' => $task['order'],
+                'id'       => $task['value']
+            ];
+        }, $tasks);
+
+        batch()->update((new Task), $tasks, 'id');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "laravel/framework": "^8.12",
         "laravel/tinker": "^2.5",
         "laravel/ui": "^3.2",
-        "livewire/livewire": "^2.4"
+        "livewire/livewire": "^2.4",
+        "mavinoo/laravel-batch": "^2.2"
     },
     "require-dev": {
         "facade/ignition": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83d0bfbe1798c0dc284fff9671634bce",
+    "content-hash": "2a5f38354fa00ee8c6d522b0bc665ff8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1473,6 +1473,59 @@
                 }
             ],
             "time": "2021-04-16T14:27:45+00:00"
+        },
+        {
+            "name": "mavinoo/laravel-batch",
+            "version": "v2.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mavinoo/laravelBatch.git",
+                "reference": "8fb12e1602def1126238e190bb874df0d97e22bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mavinoo/laravelBatch/zipball/8fb12e1602def1126238e190bb874df0d97e22bd",
+                "reference": "8fb12e1602def1126238e190bb874df0d97e22bd",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3@dev"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Mavinoo\\Batch\\BatchServiceProvider"
+                    ],
+                    "aliases": {
+                        "Batch": "Mavinoo\\Batch\\BatchFacade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mavinoo\\Batch\\": "src/"
+                },
+                "files": [
+                    "src/Common/Helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mohammad Ghanbari",
+                    "email": "mavin.developer@gmail.com"
+                }
+            ],
+            "description": "Insert and update batch (bulk) in laravel",
+            "support": {
+                "issues": "https://github.com/mavinoo/laravelBatch/issues",
+                "source": "https://github.com/mavinoo/laravelBatch/tree/v2.2.7"
+            },
+            "time": "2021-04-24T06:22:17+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/database/migrations/2021_04_27_064243_add_position_to_tasks_table.php
+++ b/database/migrations/2021_04_27_064243_add_position_to_tasks_table.php
@@ -26,7 +26,7 @@ class AddPositionToTasksTable extends Migration
     public function down()
     {
         Schema::table('tasks', function (Blueprint $table) {
-            //
+            $table->dropColumn('position');
         });
     }
 }


### PR DESCRIPTION
- Refactor to use single query instead of n*2
- Fix tasks migration rollback
