### PR TITLE
Replace \DB::raw expression by decrement in TaskController@destroy 

### DIFF
--- a/app/Http/Controllers/Admin/TaskController.php
+++ b/app/Http/Controllers/Admin/TaskController.php
@@ -37,9 +37,7 @@ class TaskController extends Controller
 
     public function destroy(Checklist $checklist, Task $task): RedirectResponse
     {
-        $checklist->tasks()->where('user_id', NULL)->where('position', '>', $task->position)->update(
-            ['position' => \DB::raw('position - 1')]
-        );
+        $checklist->tasks()->where('user_id', NULL)->where('position', '>', $task->position)->decrement('position', 1);
 
         $task->delete();
 


### PR DESCRIPTION
Instead of using a \DB::raw expression to update the positions after a Task is destroyed, we can achieve the same effect with the decrement method.